### PR TITLE
clone should only be on the levels we mutate so it does not lose knex.raw instance, etc

### DIFF
--- a/lib/fixture-generator.js
+++ b/lib/fixture-generator.js
@@ -38,19 +38,11 @@ function stripSpecIds(result) {
 
 function clone(object) {
   return _.mapValues(object, function(value) {
-    if (_.isObject(value)) {
-      return _.transform(value, function(newObject, value, key) {
-        newObject[key] = value;
-      });
-    }
-
     if (_.isArray(value)) {
-      return _.map(value, function(value) {
-        return _.extend({}, value);
-      });
+      return _.map(value, _.clone);
     }
 
-    return value;
+    return _.clone(value);
   });
 }
 

--- a/test/integration/integration-spec.js
+++ b/test/integration/integration-spec.js
@@ -83,7 +83,13 @@ describe('FixtureGenerator', function() {
       var dataConfig = {
         Users: {
           username: 'bob'
-        }
+        },
+        Items: [
+          {
+            name: "bob's item",
+            userId: 'Users:0'
+          }
+        ]
       };
 
       var originalConfig = _.cloneDeep(dataConfig);


### PR DESCRIPTION
By using `cloneDeep`, lodash changes the return value of  `knex.raw` from an instance of `Raw` into a plain object.  Knex does an instanceof check on `Raw` during insert.  If it isn't an instanceof `Raw`, it tries to `JSON.stringify` and throws a circular structure error.  This PR does a clone of only the levels we mutate.
