### PR TITLE
re-establish a connection after a disconnect if using the constructor to make a shared instance

### DIFF
--- a/lib/fixture-generator.js
+++ b/lib/fixture-generator.js
@@ -47,6 +47,7 @@ function clone(object) {
 }
 
 function FixtureGenerator(connectionConfig) {
+  this._connectionConfig = connectionConfig;
   this.knex = knex(connectionConfig);
 }
 
@@ -59,16 +60,12 @@ FixtureGenerator.prototype.create = function createRecords(dataConfig, callback)
     return fail(prioritized, callback);
   }
 
-  var knex = this.knex;
-
-  if (!knex) {
-    return fail(new Error('No connection available.'), callback);
-  }
+  var knexInst = this.knex = (this.knex || knex(this._connectionConfig));
 
   return bluebird.reduce(prioritized, function(buildingFinalResult, priorityLevel) {
     priorityLevel = resolveDependencies(buildingFinalResult, priorityLevel);
     priorityLevel = unescape(priorityLevel);
-    var priorityLevelPromises = buildPromises(knex, priorityLevel);
+    var priorityLevelPromises = buildPromises(knexInst, priorityLevel);
     return bluebird.all(priorityLevelPromises).then(function(levelResults) {
       return addToFinalResult(buildingFinalResult, levelResults, withSpecIds);
     });
@@ -83,7 +80,10 @@ FixtureGenerator.prototype.create = function createRecords(dataConfig, callback)
 
 FixtureGenerator.prototype.destroy = function destroy(callback) {
   if (this.knex) {
-    return this.knex.destroy(callback);
+    return this.knex.destroy()
+      .bind(this)
+      .tap(function(){ this.knex = null; })
+      .nodeify(callback);
   } else {
     return bluebird.resolve().nodeify(callback);
   }

--- a/test/integration/integration-spec.js
+++ b/test/integration/integration-spec.js
@@ -345,4 +345,29 @@ describe('FixtureGenerator', function() {
       });
     });
   });
+
+  describe('reusing the instance', function() {
+    it('should reconnect after a destroy', function(done) {
+      var dataConfig = {
+        Users: {
+          username: 'bob'
+        }
+      };
+
+      var fixtureGenerator = this.fixtureGenerator;
+
+      fixtureGenerator.create(dataConfig, function(err, results) {
+        expect(err).to.be.undefined;
+        expect(results.Users[0].username).to.eql('bob');
+
+        fixtureGenerator.destroy(function() {
+          fixtureGenerator.create(dataConfig, function(err, results) {
+            expect(err).to.be.undefined;
+            expect(results.Users[0].username).to.eql('bob');
+            done();
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Found a bug that caused `create` to throw when you had called `destroy` on a shared instance of FixtureGenerator.  Fixed and added a test.
