### PR TITLE
Give an option to control warning display

### DIFF
--- a/lib/fixture-generator.js
+++ b/lib/fixture-generator.js
@@ -71,7 +71,7 @@ FixtureGenerator.prototype.create = function createRecords(dataConfig, options, 
   return bluebird.reduce(prioritized, function(buildingFinalResult, priorityLevel) {
     priorityLevel = resolveDependencies(buildingFinalResult, priorityLevel);
     priorityLevel = unescape(priorityLevel);
-    var priorityLevelPromises = insertRecords(knexInst, priorityLevel, options.unique);
+    var priorityLevelPromises = insertRecords(knexInst, priorityLevel, options.unique, options.showWarning);
     return bluebird.all(priorityLevelPromises).then(function(levelResults) {
       return addToFinalResult(buildingFinalResult, levelResults, withSpecIds);
     });

--- a/lib/insert-records.js
+++ b/lib/insert-records.js
@@ -88,7 +88,7 @@ function getNoPrimaryKeyWarning(tableName) {
     " http://city41.github.io/node-sql-fixtures/#no-primary-key-warning";
 }
 
-function insertRecordsSerially(knex, tableName, insertRecords) {
+function insertRecordsSerially(knex, tableName, insertRecords, showWarning) {
   var insertedRecords = [];
 
   function insertRecordAt(index) {
@@ -98,7 +98,7 @@ function insertRecordsSerially(knex, tableName, insertRecords) {
 
         if (insertResult && insertResult[0]) {
           selectPromise = selectPromise.orderBy('id', 'DESC');
-        } else {
+        } else if (typeof showWarning === 'undefined' || showWarning === true) {
           console.warn(getNoPrimaryKeyWarning(tableName));
         }
 
@@ -115,7 +115,7 @@ function insertRecordsSerially(knex, tableName, insertRecords) {
   return insertRecordAt(0);
 }
 
-function buildInsertPromise(knex, tableName, records, unique) {
+function buildInsertPromise(knex, tableName, records, unique, showWarning) {
   var insertRecords = _.map(records, function(record) {
     return _.transform(record, removeExtraKeys);
   });
@@ -148,14 +148,14 @@ function buildInsertPromise(knex, tableName, records, unique) {
         return assembleFinalResult(insertResults);
       });
     } else {
-      return insertRecordsSerially(knex, tableName, insertRecords).then(function(insertResults) {
+      return insertRecordsSerially(knex, tableName, insertRecords, showWarning).then(function(insertResults) {
         return assembleFinalResult(insertResults);
       });
     }
   });
 }
 
-module.exports = function insertRecords(knex, configs, unique) {
+module.exports = function insertRecords(knex, configs, unique, showWarning) {
   var promises = [];
 
   _.forIn(configs, function(records, table) {
@@ -163,7 +163,7 @@ module.exports = function insertRecords(knex, configs, unique) {
       var sqlPromises = buildRawSqlPromises(knex, records);
       promises = promises.concat(sqlPromises);
     } else {
-      var insertPromise = buildInsertPromise(knex, table, records, unique);
+      var insertPromise = buildInsertPromise(knex, table, records, unique, showWarning);
       promises.push(insertPromise);
     }
   });


### PR DESCRIPTION
By default, the warning will still display, but when we setup `{showWarning: false}`, the warning won't display. For example: 

```js
var SqlFixtures = require('sql-fixtures');
var dbConfig = require('config').database;
var sqlFixtures = new SqlFixtures(dbConfig);
sqlFixtures.create({xxx: {}, {showWarning: false}});
```