### PR TITLE
Allow query for existing fk

### DIFF
--- a/lib/execute-fk-queries.js
+++ b/lib/execute-fk-queries.js
@@ -1,0 +1,36 @@
+var _ = require('lodash');
+var bluebird = require('bluebird');
+var util = require('./util');
+
+module.exports = function resolveQueryObjects(config, knexInst) {
+  var pendingQueries = [];
+
+  _.forIn(config, function(entries, table) {
+    entries = config[table] = util.asArray(entries);
+
+    entries.forEach(function(entry, index) {
+      _.forIn(entry, function(colValue, colName, record) {
+        if (isQueryObject(colValue)) {
+          var constraints = colValue;
+          pendingQueries.push(
+            knexInst(constraints.from)
+              .where(constraints.where)
+              .then(function(result) {
+                if (result.length > 1) {
+                  var where = JSON.stringify(constraints);
+                  throw new Error(where + ' matches >1 possible FK!');
+                } else {
+                  record[colName] = result[0].id;
+                }
+              })
+          );
+        }
+      });
+    });
+  });
+  return pendingQueries;
+};
+
+function isQueryObject(value) {
+  return _(value).has('from', 'where')
+}

--- a/lib/execute-fk-queries.js
+++ b/lib/execute-fk-queries.js
@@ -1,35 +1,35 @@
 var _ = require('lodash');
 var bluebird = require('bluebird');
 var util = require('./util');
+var knex;
 
 module.exports = function resolveQueryObjects(config, knexInst) {
   var pendingQueries = [];
+  knex = knexInst;
 
-  _.forIn(config, function(entries, table) {
-    entries = config[table] = util.asArray(entries);
-
-    entries.forEach(function(entry, index) {
-      _.forIn(entry, function(colValue, colName, record) {
-        if (isQueryObject(colValue)) {
-          var constraints = colValue;
-          pendingQueries.push(
-            knexInst(constraints.from)
-              .where(constraints.where)
-              .then(function(result) {
-                if (result.length > 1) {
-                  var where = JSON.stringify(constraints);
-                  throw new Error(where + ' matches >1 possible FK!');
-                } else {
-                  record[colName] = result[0].id;
-                }
-              })
-          );
-        }
-      });
+  _.forEach(config, function handleTable(entries) {
+    util.asArray(entries).forEach(function (entry) {
+      var promises = _.map(entry, resolveSingleValue);
+      pendingQueries = pendingQueries.concat(promises);
     });
   });
   return pendingQueries;
 };
+
+function resolveSingleValue(colValue, colName, entry) {
+  if (isQueryObject(colValue)) {
+    return knex(colValue.from)
+      .where(colValue.where)
+      .then(function(result) {
+        if (result.length > 1) {
+          var where = JSON.stringify(colValue);
+          throw new Error(where + ' matches >1 possible FK!');
+        } else {
+          entry[colName] = result[0].id;
+        }
+      });
+  }
+}
 
 function isQueryObject(value) {
   return _(value).has('from', 'where')

--- a/lib/fixture-generator.js
+++ b/lib/fixture-generator.js
@@ -3,6 +3,7 @@ var knex = require('knex');
 var bluebird = require('bluebird');
 
 var util = require('./util');
+var executeFkQueries = require('./execute-fk-queries');
 var generateSpecIds = require('./generate-spec-ids');
 var prioritize = require('./prioritize');
 var insertRecords = require('./insert-records');
@@ -62,36 +63,40 @@ function FixtureGenerator(knexInstanceOrConnectionConfig) {
   }
 }
 
-FixtureGenerator.prototype.create = function createRecords(dataConfig, options, callback) {
-  if (_.isFunction(options)) {
-    callback = options;
-  }
-
-  options = options || {};
-
-  dataConfig = clone(dataConfig);
-  var withSpecIds = generateSpecIds(dataConfig);
-  var prioritized = prioritize(withSpecIds);
-
-  if (prioritized instanceof Error) {
-    return fail(prioritized, callback);
-  }
-
+FixtureGenerator.prototype.create = function resolveQueriesAndCreateRecords(dataConfig, options, callback) {
   var knexInst = this.knex = (this.knex || knex(this._connectionConfig));
 
-  return bluebird.reduce(prioritized, function(buildingFinalResult, priorityLevel) {
-    priorityLevel = resolveDependencies(buildingFinalResult, priorityLevel);
-    priorityLevel = unescape(priorityLevel);
-    var priorityLevelPromises = insertRecords(knexInst, priorityLevel, options.unique, options.showWarning);
-    return bluebird.all(priorityLevelPromises).then(function(levelResults) {
-      return addToFinalResult(buildingFinalResult, levelResults, withSpecIds);
-    });
-  }, {}).then(function(finalResult) {
-    finalResult = stripSpecIds(finalResult);
-    if (callback) {
-      callback(undefined, finalResult);
+  dataConfig = clone(dataConfig);
+  var fkQueries = executeFkQueries(dataConfig, knexInst);
+
+  return bluebird.all(fkQueries).then(function createRecords() {
+    if (_.isFunction(options)) {
+      callback = options;
     }
-    return finalResult;
+
+    options = options || {};
+
+    var withSpecIds = generateSpecIds(dataConfig);
+    var prioritized = prioritize(withSpecIds);
+
+    if (prioritized instanceof Error) {
+      return fail(prioritized, callback);
+    }
+
+    return bluebird.reduce(prioritized, function(buildingFinalResult, priorityLevel) {
+      priorityLevel = resolveDependencies(buildingFinalResult, priorityLevel);
+      priorityLevel = unescape(priorityLevel);
+      var priorityLevelPromises = insertRecords(knexInst, priorityLevel, options.unique, options.showWarning);
+      return bluebird.all(priorityLevelPromises).then(function(levelResults) {
+        return addToFinalResult(buildingFinalResult, levelResults, withSpecIds);
+      });
+    }, {}).then(function(finalResult) {
+      finalResult = stripSpecIds(finalResult);
+      if (callback) {
+        callback(undefined, finalResult);
+      }
+      return finalResult;
+    });
   });
 };
 


### PR DESCRIPTION
We needed a way of referencing pre-existing data and currently I see no way of doing that easily as part of fixture `create`. What I mean by "pre-existing" is for cases when the database is _seeded_ with, typically, constant tables such as country or zip-code mappings which are too enormous to define as fixtures themselves, and which will typically be loaded one time into the database at setup (Think "rake db:seed" in Rails-terms).

This patch adds the possibility to pass an object instead of a value (the code refers to this as "the query object") with the `from` and `where` keys which will be used to lookup the ID of the pre-existing row so that we can use it for the foreign key.

Theoretical example:
```javascript
// table "countries" contains all information about supported countries
fixtures.create({
  'users': [{
    'name': 'Nisse Hult',
    'country': {from: 'countries', where: {'name': 'Sweden'}}
  }]
});
```

N.B: I saw that there is a separate gh-pages branch which duplicate index.html in it, so I did not add any documentation as I don't know how you handle that.