### PR TITLE
chore: stop using bluebird methods on knex instance

### DIFF
--- a/lib/fixture-generator.js
+++ b/lib/fixture-generator.js
@@ -99,8 +99,9 @@ FixtureGenerator.prototype.create = function resolveQueriesAndCreateRecords(data
 
 FixtureGenerator.prototype.destroy = function destroy(callback) {
   if (this.knex) {
-    return this.knex.destroy()
+    return bluebird.resolve()
       .bind(this)
+      .then(function(){ return this.knex.destroy(); })
       .tap(function(){ this.knex = null; })
       .nodeify(callback);
   } else {
@@ -124,9 +125,12 @@ FixtureGenerator.destroy = function staticDestroy(callback) {
   }
 
   // TODO: look into using bluebird's disposer pattern
-  return singleton.destroy().nodeify(callback).finally(function(){
-    singleton = null;
-  });
+  return bluebird.resolve()
+    .then(function(){ return singleton.destroy(); })
+    .nodeify(callback)
+    .finally(function(){
+      singleton = null;
+    });
 };
 
 FixtureGenerator.disconnect = FixtureGenerator.destroy;

--- a/test/integration/integration-specs.js
+++ b/test/integration/integration-specs.js
@@ -667,7 +667,7 @@ module.exports = function(dbConfig) {
           expect(err).to.not.exist;
           expect(results.simple_table[0].string_column).to.eql('a value');
 
-          myKnex.destroy().nodeify(done);
+          bluebird.resolve().then(function(){ return myKnex.destroy(); }).nodeify(done);
         });
       });
     });


### PR DESCRIPTION
After the [removal of bluebird dependency in knex](https://github.com/knex/knex/commit/b025aea31881e9a08c67ae0ccb6a4c1ceeae2ef2), `sql-fixtures` throws an error when the function `.destroy()` is called. This happens from the version `knex@0.20.11`.